### PR TITLE
add ignoreUnknownKeys option to record runtype

### DIFF
--- a/test/all.test.ts
+++ b/test/all.test.ts
@@ -710,6 +710,22 @@ describe('record', () => {
     ).toThrow('invalid keys in record')
   })
 
+  it('accepts records with non-mapped keys with ignoreUnknownKeys option', () => {
+    const runType = sr.record(
+      {
+        a: sr.integer(),
+        b: sr.string(),
+      },
+      { ignoreUnknownKeys: true },
+    )
+
+    expect(runType({ a: 1, b: 'foo', c: 'not-in-record-definition' })).toEqual({
+      a: 1,
+      b: 'foo',
+      c: 'not-in-record-definition',
+    })
+  })
+
   it('rejects records with object attributes', () => {
     const runType = sr.record({
       x: sr.number(),


### PR DESCRIPTION
Later I noticed this comment
https://github.com/hoeck/simple-runtypes/blob/7fe99ed25727a20637fcf4b5a1258849ab0847d8/src/index.ts#L920-L924

Do you prefer the record runtype with options (as in my PR) or do you prefer a separate runtype sloppyRecord with duplicated logic?