### PR TITLE
improve isPure check for record

### DIFF
--- a/src/record.ts
+++ b/src/record.ts
@@ -11,11 +11,25 @@ import {
 } from './runtype'
 import { debugValue } from './runtypeError'
 
+function isPureTypemap(typemap: object) {
+  for (const k in typemap) {
+    if (!Object.prototype.hasOwnProperty.call(typemap, k)) {
+      continue
+    }
+
+    if (!isPureRuntype(typemap[k as keyof typeof typemap])) {
+      return false
+    }
+  }
+
+  return true
+}
+
 function internalRecord<T extends object>(
   typemap: { [K in keyof T]: Runtype<T[K]> },
   sloppy: boolean,
 ): Runtype<T> {
-  const isPure = Object.values(typemap).every((t: any) => isPureRuntype(t))
+  const isPure = isPureTypemap(typemap)
   const copyObject = sloppy || !isPure
 
   const rt: Runtype<T> = internalRuntype((v, failOrThrow) => {


### PR DESCRIPTION
It makes no noticeable difference in the moltar benchmark but should in real life.
See bech: http://jsbench.github.io/#f5718be8a546d9ec07ef1d9837e806e3
But that result seems to differ alot between Chrom[e/ium] and Firefox.
What do you think?