### PR TITLE
Add missing `typeof` keyword in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ const networdStateRuntype = st.union(
   networkSuccessState,
 )
 
-type NetworkState = ReturnType<networkStateRuntype>
+type NetworkState = ReturnType<typeof networkStateRuntype>
 ```
 
 Finding the runtype to validate a specific discriminating union with is done efficiently with a [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).


### PR DESCRIPTION
Change from
```ts
type NetworkState = ReturnType<networkStateRuntype>
```
to
```ts
type NetworkState = ReturnType<typeof networkStateRuntype>
```