### PR TITLE
Make `sloppyRecord` impure

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -19,7 +19,7 @@ export const jsonRuntype = internalRuntype<unknown>((v, failOrThrow) => {
   } catch (err) {
     return createFail(failOrThrow, 'expected a json string: ' + String(err), v)
   }
-}, true)
+}, false)
 
 /**
  * A String that is valid json
@@ -39,5 +39,5 @@ export function json<T>(rt: Runtype<any>): Runtype<T> {
     }
 
     return validationResult.result
-  }, true)
+  }, false)
 }

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -130,7 +130,7 @@ export type Unpack<T> = T extends Runtype<infer U>
 // force Typescript to boil down complex mapped types to a plain interface
 export type Collapse<T> = T extends infer U ? { [K in keyof U]: U[K] } : never
 
-const isPureRuntypeSymbol = Symbol('isPure')
+export const isPureRuntypeSymbol = Symbol('isPure')
 
 // The internal runtype is one that receives an additional flag that
 // determines whether the runtype should throw a RuntypeError or whether it

--- a/test/array.test.ts
+++ b/test/array.test.ts
@@ -40,4 +40,12 @@ describe('array', () => {
 
     expectRejectValues(runtype, [undefined, null, ['asd'], [undefined, 1], '1'])
   })
+
+  it('ignores keys already ignored by sloppyRecord', () => {
+    const runtype = st.array(st.sloppyRecord({ a: st.number() }))
+
+    expect(runtype([{ a: 1, b: 'not-in-record-definition' }])).toEqual([
+      { a: 1 },
+    ])
+  })
 })

--- a/test/array.test.ts
+++ b/test/array.test.ts
@@ -1,4 +1,9 @@
-import { expectAcceptValuesPure, expectRejectValues, st } from './helpers'
+import {
+  expectAcceptValuesImpure,
+  expectAcceptValuesPure,
+  expectRejectValues,
+  st,
+} from './helpers'
 
 describe('array', () => {
   it('accepts valid arrays', () => {
@@ -41,11 +46,16 @@ describe('array', () => {
     expectRejectValues(runtype, [undefined, null, ['asd'], [undefined, 1], '1'])
   })
 
-  it('ignores keys already ignored by sloppyRecord', () => {
-    const runtype = st.array(st.sloppyRecord({ a: st.number() }))
+  it('deals with impure runtypes', () => {
+    const rt = st.array(st.string({ trim: true }))
 
-    expect(runtype([{ a: 1, b: 'not-in-record-definition' }])).toEqual([
-      { a: 1 },
-    ])
+    expectAcceptValuesImpure(
+      rt,
+      [
+        [[''], ['']],
+        [['foo '], ['foo']],
+      ],
+      true,
+    )
   })
 })

--- a/test/customRuntypes.test.ts
+++ b/test/customRuntypes.test.ts
@@ -1,6 +1,6 @@
 import * as sr from '../src'
 import { failSymbol } from '../src/runtype'
-import { expectAcceptValuesPure, expectRejectValues } from './helpers'
+import { expectRejectValues } from './helpers'
 
 describe('custom runtypes', () => {
   describe('simple nested runtypes', () => {
@@ -17,7 +17,9 @@ describe('custom runtypes', () => {
     })
 
     it('should create a custom runtype', () => {
-      expectAcceptValuesPure(rt, ['-', 31])
+      expect(rt('-')).toEqual('-')
+      expect(rt(31)).toEqual(31)
+
       expectRejectValues(rt, ['31', null, 123, []])
     })
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -18,6 +18,9 @@ export function expectAcceptValuesImpure<T>(
     const result = st.use(rt, vIn)
 
     expect(result).toEqual({ ok: true, result: vOut })
+    // this identity check does not account for unmodified primitive values,
+    // which are always identical to themselves; these cases are handled
+    // directly in the relevant tests
     expect(result.ok && result.result).not.toBe(vIn)
 
     // check both, the error throwing api and the wrapped-result returning

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -5,7 +5,7 @@ import { isPureRuntypeSymbol } from '../src/runtype'
 export * as st from '../src'
 
 // impure: the value returned by the runtype must have been modified in-place
-// and thus its a new value; the runtype will also not have an `isPure` property
+// and thus its a new value; the runtype will also not have an isPure property
 export function expectAcceptValuesImpure<T>(
   rt: st.Runtype<T>,
   values: unknown[],
@@ -27,7 +27,7 @@ export function expectAcceptValuesImpure<T>(
 }
 
 // pure: the value returned by the runtype must *not* have been modified and
-// is exactly the same value; the
+// is exactly the same value; the runtype will also have an isPure property
 export function expectAcceptValuesPure<T>(
   rt: st.Runtype<T>,
   values: unknown[],

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,15 +1,18 @@
 import * as st from '../src'
+import { isPureRuntypeSymbol } from '../src/runtype'
 
-// // re-export so tests don't depend on the weird src directory
+// re-export so tests don't depend on the weird src directory
 export * as st from '../src'
 
 // impure: the value returned by the runtype must have been modified in-place
-// and thus its a new value
+// and thus its a new value; the runtype will also not have an `isPure` property
 export function expectAcceptValuesImpure<T>(
   rt: st.Runtype<T>,
   values: unknown[],
   valuesAreTuples = false,
 ): void {
+  expect(rt).not.toHaveProperty('isPure')
+
   values.forEach((v) => {
     const [vIn, vOut] = valuesAreTuples ? (v as [unknown, unknown]) : [v, v]
     const result = st.use(rt, vIn)
@@ -24,11 +27,13 @@ export function expectAcceptValuesImpure<T>(
 }
 
 // pure: the value returned by the runtype must *not* have been modified and
-// is exactly the same value
+// is exactly the same value; the
 export function expectAcceptValuesPure<T>(
   rt: st.Runtype<T>,
   values: unknown[],
 ): void {
+  expect(rt).toHaveProperty('isPure', isPureRuntypeSymbol)
+
   values.forEach((v) => {
     const result = st.use(rt, v)
 

--- a/test/nullOr.test.ts
+++ b/test/nullOr.test.ts
@@ -1,4 +1,9 @@
-import { expectAcceptValuesPure, expectRejectValues, st } from './helpers'
+import {
+  expectAcceptValuesImpure,
+  expectAcceptValuesPure,
+  expectRejectValues,
+  st,
+} from './helpers'
 
 describe('nullOr', () => {
   it('accepts null or T', () => {
@@ -8,11 +13,19 @@ describe('nullOr', () => {
   it('deals with impure runtypes', () => {
     const rt = st.nullOr(st.string({ trim: true }))
 
-    expect(rt).not.toHaveProperty('isPure')
+    expectAcceptValuesImpure(
+      rt,
+      [
+        [' ', ''],
+        ['foo ', 'foo'],
+      ],
+      true,
+    )
 
+    // we need to test unmodified primitive values directly because the
+    // test helper assumes that the runtype result will not be identical
+    // to the original value
     expect(rt(null)).toEqual(null)
-    expect(rt('')).toEqual('')
-    expect(rt('foo ')).toEqual('foo')
   })
 
   it('rejects non-null and non-T', () => {

--- a/test/nullOr.test.ts
+++ b/test/nullOr.test.ts
@@ -6,11 +6,13 @@ describe('nullOr', () => {
   })
 
   it('deals with impure runtypes', () => {
-    expectAcceptValuesPure(st.nullOr(st.string({ trim: true })), [
-      null,
-      'foo',
-      '',
-    ])
+    const rt = st.nullOr(st.string({ trim: true }))
+
+    expect(rt).not.toHaveProperty('isPure')
+
+    expect(rt(null)).toEqual(null)
+    expect(rt('')).toEqual('')
+    expect(rt('foo ')).toEqual('foo')
   })
 
   it('rejects non-null and non-T', () => {

--- a/test/undefinedOr.test.ts
+++ b/test/undefinedOr.test.ts
@@ -6,11 +6,13 @@ describe('undefinedOr', () => {
   })
 
   it('deals with impure runtypes', () => {
-    expectAcceptValuesPure(st.undefinedOr(st.string({ trim: true })), [
-      undefined,
-      'foo',
-      '',
-    ])
+    const rt = st.undefinedOr(st.string({ trim: true }))
+
+    expect(rt).not.toHaveProperty('isPure')
+
+    expect(rt(undefined)).toEqual(undefined)
+    expect(rt('')).toEqual('')
+    expect(rt('foo ')).toEqual('foo')
   })
 
   it('rejects non-undefined and non-T', () => {

--- a/test/undefinedOr.test.ts
+++ b/test/undefinedOr.test.ts
@@ -1,4 +1,9 @@
-import { expectAcceptValuesPure, expectRejectValues, st } from './helpers'
+import {
+  expectAcceptValuesImpure,
+  expectAcceptValuesPure,
+  expectRejectValues,
+  st,
+} from './helpers'
 
 describe('undefinedOr', () => {
   it('accepts undefined or T', () => {
@@ -8,11 +13,19 @@ describe('undefinedOr', () => {
   it('deals with impure runtypes', () => {
     const rt = st.undefinedOr(st.string({ trim: true }))
 
-    expect(rt).not.toHaveProperty('isPure')
+    expectAcceptValuesImpure(
+      rt,
+      [
+        [' ', ''],
+        ['foo ', 'foo'],
+      ],
+      true,
+    )
 
+    // we need to test unmodified primitive values directly because the
+    // test helper assumes that the runtype result will not be identical
+    // to the original value
     expect(rt(undefined)).toEqual(undefined)
-    expect(rt('')).toEqual('')
-    expect(rt('foo ')).toEqual('foo')
   })
 
   it('rejects non-undefined and non-T', () => {


### PR DESCRIPTION
### Issues fixed

- #60 


### Overview of changes

`sloppyRecord` is technically an impure runtype as it may 'remove' keys from the original value passed in if the value has unknown/extra keys (keys that are not in the `sloppyRecord` definition). Therefore, this PR makes sure a `sloppyRecord` is set as impure.


### Detail of changes

The problem reported in the linked issue arose because a `sloppyRecord` could (incorrectly) be seen as pure if the runtypes of its keys were pure. However, this doesn't take into account the unique property of a `sloppyRecord`: it ignores/removes any extra keys that are not in its definition. What this means is that, like other _impure_ runtypes, it needs to, in some sense, construct a new copy of the original value, modify the copy, and return the copy, rather than returning the original value after various checks have been performed. (To return the original value with the unknown keys removed you would need to `delete` those keys, thus modifying the original value in-place, which `simple-runtypes` does not do.)

Before the changes in this PR, `internalRecord` used three variables to decide whether to use the original value versus building up a new copy: `isPure`, `copyObject`, and `sloppy`.

```ts
// src/record.ts

const isPure = isPureTypemap(typemap)
const copyObject = sloppy || !isPure
```

Because `copyObject` was based on both `isPure` and `sloppy`, it could happen that all the runtypes of the `sloppyRecord`'s keys were pure, but the `sloppyRecord` was still sloppy (i.e. `sloppy` is `true`), and so `copyObject` would be true. This would result in the `sloppyRecord` being pure, but unlike other pure runtypes, the value passed to it would be copied rather than the original value being returned after passing various checks.

Then, for the `array` runtype, an `array` is considered pure if the runtype that it is a container for is pure:

```ts
// src/array.ts

function array<A>(
  a: Runtype<A>,
  ...
) {
  ...
  const isPure = isPureRuntype(a)
  ...
}
```

In the old behaviour, an `array` could therefore be pure if it contained a `sloppyRecord` which was pure, which would be the case if all the runtypes of the `sloppyRecord`'s keys were pure. Because the `array` would be seen as pure, it would keep the original value instead of building up a new copy:

```ts
// src/array.ts

// `arrayValue` would be used rather than creating a new array
const res: A[] = isPure ? arrayValue : new Array(arrayValue.length) 
```

and it would also, therefore, not use the result of applying the `sloppyRecord` to its elements' values, and therefore the extra keys that were ignored by applying `sloppyRecord` would not continue to be ignored. Rather, the original element would be kept/used.

```ts
// src/array.ts

for (let i = 0; i < arrayValue.length; i++) {
  // `item` would contain the result of applying `sloppyRecord`, and thus could have
  // had some of its original keys (from `arrayValue[i]`) ignored
  const item = (a as InternalRuntype)(arrayValue[i], failSymbol) // `a` would be a `sloppyRecord`

  if (isFail(item)) {
    return propagateFail(failOrThrow, item, v, i)
  }

  // because the array was seen as pure, it would not use the result (`item`)
  // of applying `sloppyRecord`
  if (!isPure) { 
    res[i] = item
  }
}

// `res` would be the original array, which, importantly for the current issue, contains
// the elements with all of their *original* keys 
return res 
```

The above would also happen for the `tuple` container runtype.

_Note: I think it's helpful to have in mind that impurity is contagious (kind of like `async`) 🙃_ 


### Other notes

1. The changes made in this PR assume that any `sloppyRecord` is impure. However, technically, a `sloppyRecord` is only impure if it needs to remove/ignore keys. The current, broader changes (i.e. "all `sloppyRecords` are impure) were easier to implement, so I went with them for now.
2. I'm not sure if there are any performance considerations for the current changes 🤔 The `sloppyRecord`s that would have built up new objects would still do so with these changes, but the `array` would have previously ignored the newly-built objects; whereas now the `array` would built up a new array.
3. Even though the change was made in `record.ts`, I have not changed `record.test.ts`. This is because the check for impurity that is done in `expectAcceptValuesImpure`, checks that the returned object is the _same_ object as the one that was provided. For `sloppyRecord`s the objects would've been different because `copyObject == true`, even if the `sloppyRecord` was pure. So the tests still pass because the test for impurity still passes because it is checking for object equality (and not also checking `.isPure`). I'm not sure if any of this should be updated to check both object equality and `.isPure`? 
4. I added a test for an `array` that contains a `sloppyRecord`, which now passes, but fails before the change. Should I add more? I can also add a `sloppyRecord` test in the `tuple` tests, but I just wanted to put this PR up first before prematurely going further into this. Should these kinds of tests -- that are testing the interaction between different complex runtypes -- be in a separate test file?