### PR TITLE
Update github action versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,9 +47,9 @@ jobs:
     name: ${{ matrix.os }} Node ${{ matrix.node }} cache
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2.1.5
+      - uses: actions/setup-node@v3.4.1
         with:
           node-version: ${{ matrix.node }}
           registry-url: https://registry.npmjs.org/
@@ -59,7 +59,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2.1.5
+      - uses: actions/cache@v3.0.5
         id: cache
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,9 +25,9 @@ jobs:
       NODE: ${{ matrix.node }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2.1.5
+      - uses: actions/setup-node@v3.4.1
         with:
           node-version: ${{ matrix.node }}
 
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2.1.5
+      - uses: actions/cache@v3.0.5
         id: cache
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}


### PR DESCRIPTION
- updates [actions/cache](https://github.com/actions/cache) from 2.1.5 to 3.0.5
- updates [actions/setup-node](https://github.com/actions/setup-node) from 2.1.5 to 3.4.1
- updates [actions/checkout](https://github.com/actions/checkout) from 2 to 3

Incorporates changes from #47, #66, and #66 (they can be closed if this is merged).