### PR TITLE
Fix typing of `json` runtype output

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -24,8 +24,8 @@ export const jsonRuntype = internalRuntype<unknown>((v, failOrThrow) => {
 /**
  * A String that is valid json
  */
-export function json<T>(rt: Runtype<any>): Runtype<T> {
-  return internalRuntype<T>((v, failOrThrow) => {
+export function json<T>(rt: Runtype<T>): Runtype<T> {
+  return internalRuntype<any>((v, failOrThrow) => {
     const n = (jsonRuntype as InternalRuntype)(v, failOrThrow)
 
     if (isFail(n)) {

--- a/test-d/json.test-d.ts
+++ b/test-d/json.test-d.ts
@@ -1,0 +1,27 @@
+import { expectType } from 'tsd'
+import * as st from '../src'
+
+const data: unknown = null
+
+// basic
+{
+  // number
+  const jsonNumberRt = st.json(st.number())
+
+  expectType<number>(jsonNumberRt(data))
+
+  // string
+  const jsonStringRt = st.json(st.string())
+
+  expectType<string>(jsonStringRt(data))
+
+  // array
+  const jsonArrayRt = st.json(st.array(st.number()))
+
+  expectType<number[]>(jsonArrayRt(data))
+
+  // object
+  const jsonObjectRt = st.json(st.record({ a: st.string() }))
+
+  expectType<{ a: string }>(jsonObjectRt(data))
+}

--- a/test-d/record.test-d.ts
+++ b/test-d/record.test-d.ts
@@ -35,3 +35,18 @@ const data: unknown = null
 
   expectType<{ a: { b: { c: string } } }>(rt(data))
 }
+
+// record with json
+{
+  const rt = st.record({
+    a: st.string(),
+    b: st.json(
+      st.record({
+        c: st.string(),
+      }),
+    ),
+    d: st.string(),
+  })
+
+  expectType<{ a: string; b: { c: string }; d: string }>(rt(data))
+}


### PR DESCRIPTION
_Reproduction of issue:_ [codesandbox.io](https://codesandbox.io/s/simple-runtypes-json-return-type-error-reproduction-2-md0euy)

While using the `json` runtype for the first time lately, I noticed that, while the runtype was working in terms of producing the correct output, it was losing type information. For example, after adding the tests from this PR, but before changing anything in `src/json.ts`, if I ran `yarn test:types` I got the following output:
<details>
  <summary>output</summary>

```  
❯ yarn run test:types
yarn run v1.22.19
$ tsd

  test-d/json.test-d.ts:11:21
  ✖  11:21  Argument of type unknown is not assignable to parameter of type number.                                                                                                                                                                       
  ✖  16:21  Argument of type unknown is not assignable to parameter of type string.                                                                                                                                                                       
  ✖  21:23  Argument of type unknown is not assignable to parameter of type number[].                                                                                                                                                                     
  ✖  26:28  Argument of type unknown is not assignable to parameter of type { a: string; }.                                                                                                                                                               

  test-d/record.test-d.ts:51:57
  ✖  51:57  Argument of type { a: string; b: unknown; d: string; } is not assignable to parameter of type { a: string; b: { c: string; }; d: string; }.
  Types of property b are incompatible.
    Type unknown is not assignable to type { c: string; }.  

  5 errors

error Command failed with exit code 1.
```
</details>


And in VS Code I can see the following in the `json` tests that already exist in `test/json.test.ts`:

<details>
  <summary>screenshot</summary>
  
  ![2022-08-07-11 02](https://user-images.githubusercontent.com/8270635/183273122-c57815e1-4ef1-4f98-b775-c23c48bbd8ee.png)
</details>


After making this PR's changes in `src/json.ts`, the tests pass and I see the following in VS Code:

<details>
  <summary>screenshot</summary>
  
 ![2022-08-07-11 16](https://user-images.githubusercontent.com/8270635/183273470-f03262af-9ac6-4e96-afe9-8c856180b72f.png)
</details>


