### PR TITLE
Add `nonStrict` modifier for `record` runtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Unreleased
+
+- add `nonStrict` combinator ([#90](https://github.com/hoeck/simple-runtypes/pull/90))
+  - `nonStrict` creates a non-strict `record` runtype from a provided `record` runtype
+  - a non-strict `record` runtype will ignore keys that are not specified in the original runtype's typemap
+  - non-strict `record` runtypes will replace `sloppyRecord` runtypes
+
 ### 7.1.3
 
 - fix: invalid key message was displaying the object instead of the keys, see [#91](https://github.com/hoeck/simple-runtypes/issues/91)

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ That's how runtypes work.
 - [Documentation](#documentation)
   * [Intro](#intro)
   * [Usage Examples](#usage-examples)
-    + [Strict Property Checks](#strict-property-checks)
-    + [Optional Properties](#optional-properties)
     + [Nesting](#nesting)
+    + [Strict Property Checks](#strict-property-checks)
+    + [Ignore Individual Properties](#ignore-individual-properties)
+    + [Optional Properties](#optional-properties)
+    + [Non-strict Property Checks](#non-strict-property-checks)
     + [Discriminating Unions](#discriminating-unions)
     + [Custom Runtypes](#custom-runtypes)
   * [Reference](#reference)
@@ -30,7 +32,13 @@ That's how runtypes work.
 
 ## Install
 
-`npm install simple-runtypes` or `yarn add simple-runtypes`
+```sh
+# npm
+npm install simple-runtypes
+
+# yarn
+yarn add simple-runtypes
+```
 
 ## Example
 
@@ -40,9 +48,9 @@ That's how runtypes work.
 import * as st from 'simple-runtypes'
 
 const userRuntype = st.record({
-    id: st.integer(),
-    name: st.string(),
-    email: st.optional(st.string()),
+  id: st.integer(),
+  name: st.string(),
+  email: st.optional(st.string()),
 })
 ```
 
@@ -50,29 +58,29 @@ now, `ReturnType<typeof userRuntype>` is equivalent to
 
 ```typescript
 interface {
-    id: number,
-    name: string,
-    email?: string
+  id: number
+  name: string
+  email?: string
 }
 ```
 
 2. Use the runtype to validate untrusted data
 
 ```typescript
-userRuntype({id: 1, name: 'matt'})
+userRuntype({ id: 1, name: 'matt' })
 // => {id: 1, name: 'matt'}
 
-userRuntype({id: 1, name: 'matt', isAdmin: true})
+userRuntype({ id: 1, name: 'matt', isAdmin: true })
 // throws an st.RuntypeError: "invalid field 'isAdmin' in data"
 ```
 
 Invoke a runtype with [`use`](src/custom.ts#L51) to get a plain value back instead of throwing errors:
 
 ```typescript
-st.use(userRuntype, {id: 1, name: 'matt'})
+st.use(userRuntype, { id: 1, name: 'matt' })
 // => {ok: true, result: {id: 1, name: 'matt'}}
 
-st.use(userRuntype, {id: 1, name: 'matt', isAdmin: true})
+st.use(userRuntype, { id: 1, name: 'matt', isAdmin: true })
 // => {ok: false, error: FAIL}
 
 st.getFormattedError(FAIL)
@@ -86,10 +94,10 @@ Throwing errors and catching them outside is more convenient.
 
 Why should I use this over the plethora of [other](https://github.com/moltar/typescript-runtime-type-benchmarks#packages-compared) runtype validation libraries available?
 
-1. Strict: by default safe against proto injection attacks and unwanted properties
-2. Fast: check the [benchmark](https://github.com/moltar/typescript-runtime-type-benchmarks)
-3. Friendly: no use of `eval`, a small [footprint](https://bundlephobia.com/result?p=simple-runtypes) and no dependencies
-4. Flexible: optionally modify the data while it's being checked: trim strings, convert numbers, parse dates
+1. **Strict**: by default safe against `__proto__` injection attacks and unwanted properties
+2. **Fast**: check the [benchmark](https://github.com/moltar/typescript-runtime-type-benchmarks)
+3. **Friendly**: no use of `eval`, and a small [footprint](https://bundlephobia.com/result?p=simple-runtypes) with no dependencies
+4. **Flexible**: optionally modify the data while it's being checked - trim strings, convert numbers, parse dates
 
 ## Benchmarks
 
@@ -110,7 +118,7 @@ A [`Runtype`](src/runtype.ts#L106) is a function that:
 
 ```typescript
 interface Runtype<T> {
-    (v: unknown) => T
+  (v: unknown) => T
 }
 ```
 
@@ -120,51 +128,9 @@ Check the factory functions documentation for more details.
 
 ### Usage Examples
 
-#### Strict Property Checks
-
-When using [`record`](src/record.ts#L134), any properties which are not defined in the runtype will cause the runtype to fail:
-
-```typescript
-const strict = st.record({name: st.string()})
-
-strict({name: 'foo', other: 123})
-// => RuntypeError: Unknown attribute 'other'
-```
-
-To ignore single properties, use [`ignore`](src/ignore.ts#L6), [`unknown`](src/unknown.ts#L6) or [`any`](src/any.ts#L6):
-
-```typescript
-const strict = st.record({name: st.string(), other: st.ignore()})
-
-strict({name: 'foo', other: 123})
-// => {name: foo, other: undefined}
-```
-
-Use [`sloppyRecord`](src/record.ts#L159) to only validate known properties and remove everything else:
-
-```typescript
-const sloppy = st.sloppyRecord({name: st.string()})
-
-sloppy({name: 'foo', other: 123, bar: []})
-// => {name: foo}
-```
-
-Using any of [`record`](src/record.ts#L134) or [`sloppyRecord`](src/record.ts#L159) will keep you safe from any `__proto__` injection or overriding attempts.
-
-#### Optional Properties
-
-Use the [`optional`](src/optional.ts#L18) runtype to create [optional properties](https://www.typescriptlang.org/docs/handbook/interfaces.html#optional-properties):
-
-```typescript
-const squareConfigRuntype = st.record({
-  color: st.optional(st.string()),
-  width?: st.optional(st.number()),
-})
-```
-
 #### Nesting
 
-Collection runtypes such as [`record`](src/record.ts#L134), [`array`](src/array.ts#L28), [`tuple`](src/tuple.ts#L42) take runtypes as their parameters:
+Collection runtypes such as [`record`](src/record.ts#L141), [`array`](src/array.ts#L28), and [`tuple`](src/tuple.ts#L42) take runtypes as their parameters:
 
 ```typescript
 const nestedRuntype = st.record({
@@ -176,6 +142,52 @@ nestedRuntype({
   name: 'foo',
   items: [{ id: 3, label: 'bar' }],
 }) // => returns the same data
+```
+
+#### Strict Property Checks
+
+When using [`record`](src/record.ts#L141), any properties which are not defined in the runtype will cause the runtype to fail:
+
+```typescript
+const strict = st.record({ name: st.string() })
+
+strict({ name: 'foo', other: 123 })
+// => RuntypeError: Unknown attribute 'other'
+```
+
+Using [`record`](src/record.ts#L141) will keep you safe from any `__proto__` injection or overriding attempts.
+
+#### Ignore Individual Properties
+
+To ignore individual properties, use [`ignore`](src/ignore.ts#L6), [`unknown`](src/unknown.ts#L6) or [`any`](src/any.ts#L6):
+
+```typescript
+const strict = st.record({ name: st.string(), other: st.ignore() })
+
+strict({ name: 'foo', other: 123 })
+// => {name: foo, other: undefined}
+```
+
+#### Optional Properties
+
+Use the [`optional`](src/optional.ts#L18) runtype to create [optional properties](https://www.typescriptlang.org/docs/handbook/interfaces.html#optional-properties):
+
+```typescript
+const strict = st.record({
+  color: st.optional(st.string()),
+  width: st.optional(st.number()),
+})
+```
+
+#### Non-strict Property Checks
+
+Use [`nonStrict`](src/nonStrict.ts#L16) to only validate known properties and remove everything else:
+
+```typescript
+const nonStrictRecord = st.nonStrict(st.record({ name: st.string() }))
+
+nonStrictRecord({ name: 'foo', other: 123, bar: [] })
+// => {name: foo}
 ```
 
 #### Discriminating Unions
@@ -219,16 +231,16 @@ Finding the runtype to validate a specific discriminating union with is done eff
 Write your own runtypes as plain functions, e.g. if you want to turn a string into a `BigInt`:
 
 ```typescript
-const bigIntStringRuntype = st.string({match: /^-?[0-9]+n$/})
+const bigIntStringRuntype = st.string({ match: /^-?[0-9]+n$/ })
 
 const bigIntRuntype = st.runtype((v) => {
-    const stringCheck = st.use(bigIntStringRuntype, v)
+  const stringCheck = st.use(bigIntStringRuntype, v)
 
-    if (!stringCheck.ok) {
-        return stringCheck.error
-    }
+  if (!stringCheck.ok) {
+      return stringCheck.error
+  }
 
-    return BigInt(stringCheck.result.slice(0, -1))
+  return BigInt(stringCheck.result.slice(0, -1))
 })
 
 bigIntRuntype("123n") // => 123n
@@ -260,9 +272,8 @@ Objects and Array Runtypes:
 
 - [`tuple`](src/tuple.ts#L42)
 - [`array`](src/array.ts#L28)
-- [`record`](src/record.ts#L134)
+- [`record`](src/record.ts#L141)
   - [`optional`](src/optional.ts#L18)
-- [`sloppyRecord`](src/record.ts#L159)
 - [`dictionary`](src/dictionary.ts#L87)
 
 Combinators:
@@ -272,6 +283,7 @@ Combinators:
 - [`omit`](src/omit.ts#L8)
 - [`pick`](src/pick.ts#L7)
 - [`partial`](src/partial.ts#L10)
+- [`nonStrict`](src/nonStrict.ts#L16)
 - TODO: `get` - similar to Type[key]
 
 Shortcuts:
@@ -285,7 +297,6 @@ Shortcuts:
 - rename [`stringLiteralUnion`](src/stringLiteralUnion.ts#L6) to `literals` or `literalUnion` and make it work
   on all types that [`literal`](src/literal.ts#L10) accepts
 - rename record to object: [#69](https://github.com/hoeck/simple-runtypes/issues/69)
-- nonStrict modifier instead of sloppy: [#68](https://github.com/hoeck/simple-runtypes/issues/68)
 - improve docs:
   - *preface*: what is a runtype and why is it useful
   - *why*: explain or link to example that shows "strict by default"
@@ -295,5 +306,5 @@ Shortcuts:
   - add small frontend and backend example projects that show how to use `simple-runtypes` in production
 - test *all* types with [tsd](https://github.com/SamVerschueren/tsd)
 - add more combinators: partial, required, get, ...
-- separate `Runtype` and `InternalRuntype` and type runtype internals
+- separate [`Runtype`](src/runtype.ts#L106) and [`InternalRuntype`](src/runtype.ts#L171) and type runtype internals
   (see [this comment](https://github.com/hoeck/simple-runtypes/pull/73#discussion_r948841977))

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export { dictionary } from './dictionary'
 
 // advanced / utility types
 export { intersection } from './intersection'
+export { nonStrict } from './nonStrict'
 export { omit } from './omit'
 export { partial } from './partial'
 export { pick } from './pick'

--- a/src/nonStrict.ts
+++ b/src/nonStrict.ts
@@ -1,6 +1,18 @@
 import { internalRecord } from './record'
 import { Runtype, RuntypeUsageError } from './runtype'
 
+/**
+ * Build a non-strict `record` runtype from the provided `record` runtype.
+ *
+ * In contrast to a `record` runtype, a non-strict `record` runtype will ignore
+ * keys that are not specified in the original runtype's typemap (non-strict checking).
+ *
+ * When a non-strict `record` runtype checks an object, it will return a new
+ * object that contains only the keys specified in the original runtype's typemap.
+ *
+ * Non-strict checking only applies to the root typemap. To apply non-strict checking
+ * to a nested typemap, `nonStrict` needs to be used at each level of the typemap.
+ */
 export function nonStrict<T>(original: Runtype<T>): Runtype<T> {
   const fields = (original as any).fields
 

--- a/src/nonStrict.ts
+++ b/src/nonStrict.ts
@@ -1,0 +1,12 @@
+import { internalRecord } from './record'
+import { Runtype, RuntypeUsageError } from './runtype'
+
+export function nonStrict<T>(original: Runtype<T>): Runtype<T> {
+  const fields = (original as any).fields
+
+  if (!fields) {
+    throw new RuntypeUsageError('expected a record runtype')
+  }
+
+  return internalRecord(fields, true)
+}

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -1,5 +1,5 @@
-import { record } from './record'
-import { Runtype, RuntypeUsageError } from './runtype'
+import { internalRecord } from './record'
+import { Runtype, RuntypeUsageError, isNonStrictRuntype } from './runtype'
 
 /**
  * Build a new record runtype that omits some keys from the original.
@@ -21,6 +21,8 @@ export function omit<T, K extends keyof T>(
     delete newRecordFields[k]
   })
 
-  // TODO: keep 'sloppyness'
-  return record(newRecordFields) as Runtype<any>
+  return internalRecord(
+    newRecordFields,
+    isNonStrictRuntype(original),
+  ) as Runtype<any>
 }

--- a/src/partial.ts
+++ b/src/partial.ts
@@ -1,6 +1,6 @@
 import { optional } from './optional'
-import { record } from './record'
-import { Runtype, RuntypeUsageError } from './runtype'
+import { internalRecord } from './record'
+import { Runtype, RuntypeUsageError, isNonStrictRuntype } from './runtype'
 
 /**
  * Build a new record runtype that marks all keys as optional.
@@ -26,6 +26,8 @@ export function partial<T, K extends keyof T>(
     }
   }
 
-  // TODO: keep 'sloppyness'
-  return record(newRecordFields) as Runtype<any>
+  return internalRecord(
+    newRecordFields,
+    isNonStrictRuntype(original),
+  ) as Runtype<any>
 }

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -1,5 +1,5 @@
-import { record } from './record'
-import { Runtype, RuntypeUsageError } from './runtype'
+import { internalRecord } from './record'
+import { Runtype, RuntypeUsageError, isNonStrictRuntype } from './runtype'
 
 /**
  * Build a new record runtype that contains some keys from the original
@@ -20,6 +20,8 @@ export function pick<T, K extends keyof T>(
     newRecordFields[k] = fields[k]
   })
 
-  // TODO: keep 'sloppyness'
-  return record(newRecordFields) as Runtype<any>
+  return internalRecord(
+    newRecordFields,
+    isNonStrictRuntype(original),
+  ) as Runtype<any>
 }

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -183,3 +183,9 @@ export function isFail(v: unknown): v is Fail {
 
   return (v as any)[failSymbol]
 }
+
+export function isNonStrictRuntype(fn: Runtype<any>): boolean {
+  return !!(fn as any).isNonStrict
+}
+
+export const isNonStrictRuntypeSymbol = Symbol('isNonStrict')

--- a/test/nonStrict.test.ts
+++ b/test/nonStrict.test.ts
@@ -1,0 +1,155 @@
+import {
+  expectAcceptValuesImpure,
+  expectRejectValues,
+  objectAttributes,
+  st,
+} from './helpers'
+
+describe('nonStrict', () => {
+  it('accepts records', () => {
+    const runtype = st.nonStrict(
+      st.record({
+        a: st.integer(),
+        b: st.string(),
+      }),
+    )
+
+    // a nonStrict runtype is always impure
+    expectAcceptValuesImpure(
+      runtype,
+      [
+        [
+          { a: 0, b: 'foo', c: true }, // ignores additional keys
+          { a: 0, b: 'foo' },
+        ],
+      ],
+      true,
+    )
+  })
+
+  it('accepts nonStrict records', () => {
+    const runtype = st.nonStrict(
+      st.nonStrict(
+        st.record({
+          a: st.integer(),
+          b: st.string(),
+        }),
+      ),
+    )
+
+    expectAcceptValuesImpure(
+      runtype,
+      [
+        [
+          { a: 0, b: 'foo', c: true },
+          { a: 0, b: 'foo' },
+        ],
+      ],
+      true,
+    )
+  })
+
+  it('accepts records with optional values', () => {
+    const runtype = st.nonStrict(
+      st.record({
+        a: st.integer(),
+        b: st.optional(st.string()),
+      }),
+    )
+
+    expectAcceptValuesImpure(
+      runtype,
+      [
+        [
+          { a: 0, b: 'foo', c: true },
+          { a: 0, b: 'foo' },
+        ],
+        [
+          { a: 0, b: undefined, c: true }, // ignores additional keys
+          { a: 0, b: undefined },
+        ],
+      ],
+      true,
+    )
+  })
+
+  it('accepts nested records and does not apply recursively', () => {
+    const runtype = st.nonStrict(
+      st.record({
+        a: st.record({
+          b: st.record({
+            c: st.string(),
+          }),
+        }),
+      }),
+    )
+
+    expectAcceptValuesImpure(
+      runtype,
+      [[{ a: { b: { c: 'foo' } }, d: 0 }, { a: { b: { c: 'foo' } } }]],
+      true,
+    )
+    expectRejectValues(runtype, [
+      { a: { b: { c: 'foo' }, d: 0 } },
+      { a: { b: { c: 'foo', d: 0 } } },
+    ])
+  })
+
+  it('rejects runtypes that are not records', () => {
+    const nonRecordRuntypes: any[] = [
+      st.array(st.string()),
+      st.dictionary(st.union(st.literal('a'), st.literal('b')), st.boolean()),
+      st.enum({ A: 'a', B: 'b' }),
+      st.literal(0),
+      st.null(),
+      st.string(),
+      st.tuple(st.string(), st.number()),
+      st.undefined(),
+      st.union(st.string(), st.number()),
+
+      // An intersection runtype not between two record runtypes. This is because an intersection between two
+      // record runtypes would result in a record runtype, which is valid to use with nonStrict.
+      st.intersection(
+        st.union(
+          st.record({ tier: st.literal('One'), price: st.number() }),
+          st.record({
+            tier: st.literal('Two'),
+            price: st.number(),
+            access: st.boolean(),
+          }),
+        ),
+        st.record({ c: st.boolean() }),
+      ),
+    ]
+
+    nonRecordRuntypes.forEach((runtype) => {
+      expect(() => {
+        st.nonStrict(runtype)
+      }).toThrow('expected a record runtype')
+    })
+  })
+
+  // same as sloppyRecord
+  it('ignores object attributes', () => {
+    const runType = st.nonStrict(
+      st.record({
+        x: st.number(),
+      }),
+    )
+
+    objectAttributes
+      // JSON.parse bc the __proto__ attr cannot be assigned in js
+      .map((a) => ({ a, o: JSON.parse(`{"x": 1, "${a}": {"y":2}}`) }))
+      .forEach(({ a, o }) => {
+        const x = runType(o)
+        const y = runType(Object.assign({}, o))
+        expect(x).not.toBe(o)
+        expect(x).toEqual({ x: 1 })
+        expect(y).toEqual({ x: 1 })
+        expect((x as any).y).toBeUndefined()
+        expect((y as any).y).toBeUndefined()
+        expect(Object.prototype.hasOwnProperty.call(x, a)).toBeFalsy()
+        expect(Object.prototype.hasOwnProperty.call(y, a)).toBeFalsy()
+      })
+  })
+})

--- a/test/partial.test.ts
+++ b/test/partial.test.ts
@@ -1,4 +1,9 @@
-import { expectAcceptValuesPure, expectRejectValues, st } from './helpers'
+import {
+  expectAcceptValuesImpure,
+  expectAcceptValuesPure,
+  expectRejectValues,
+  st,
+} from './helpers'
 
 describe('partial', () => {
   const record = st.record({
@@ -49,5 +54,15 @@ describe('partial', () => {
     ]
 
     expectRejectValues(partialRt, rejectedValues)
+  })
+
+  it('should preserve nonStrict', () => {
+    const nonStrictRecordRuntype = st.nonStrict(st.record({ a: st.string() }))
+    const partialRuntype = st.partial(nonStrictRecordRuntype)
+    expectAcceptValuesImpure(
+      partialRuntype,
+      [[{ a: 'a', b: 'b' }, { a: 'a' }]],
+      true,
+    )
   })
 })

--- a/test/pick.omit.test.ts
+++ b/test/pick.omit.test.ts
@@ -1,4 +1,9 @@
-import { expectAcceptValuesPure, expectRejectValues, st } from './helpers'
+import {
+  expectAcceptValuesImpure,
+  expectAcceptValuesPure,
+  expectRejectValues,
+  st,
+} from './helpers'
 
 describe('pick & omit', () => {
   const record = st.record({
@@ -36,6 +41,31 @@ describe('pick & omit', () => {
 
     expectRejectValues(pickedRt, rejectedValues)
     expectRejectValues(omittedRt, rejectedValues)
+  })
+
+  it('should preserve nonStrict', () => {
+    const nonStrictRecordRuntype = st.nonStrict(
+      st.record({ a: st.string(), b: st.string(), c: st.string() }),
+    )
+
+    const pickedRuntype = st.pick(nonStrictRecordRuntype, 'a', 'b')
+    const omittedRuntype = st.omit(nonStrictRecordRuntype, 'a', 'b')
+
+    expectAcceptValuesImpure(
+      pickedRuntype,
+      [
+        [
+          { a: 'a', b: 'b', c: 'c', d: 'd' },
+          { a: 'a', b: 'b' },
+        ],
+      ],
+      true,
+    )
+    expectAcceptValuesImpure(
+      omittedRuntype,
+      [[{ a: 'a', b: 'b', c: 'c', d: 'd' }, { c: 'c' }]],
+      true,
+    )
   })
 })
 


### PR DESCRIPTION
Fixes:
- #68
- #23

## Description

### Context

The default mode of a `record` runtype is **strict**, where _strictness_ refers to how a runtype treats excess keys in untrusted input data:
- **strict**: treats excess keys as an error
- **non-strict**: ignores excess keys

Because the `record` runtype is strict by default, excess keys in its input will be treated as an error:  

```ts
import * as st from "simple-runtypes"

const user = st.record({
  id: st.integer(),
  name: st.string()
})

user({ id: 1, name: "Matt" })
// => { id: 1, name: "Matt" }

user({ id: 1, name: "Matt", isAdmin: true })
// => throws st.RuntypeError: invalid keys in record

st.use(user, { id: 1, name: "Matt", isAdmin: true })
// => { ok: false, error: { reason: 'invalid keys in record [...]', ... } }
```

`simple-runtypes` currently also offers a **non-strict** version of the `record` runtype, which is called the `sloppyRecord` runtype. Because it is non-strict, `sloppyRecord` ignores excess keys:

```ts
const sloppyUser = st.sloppyRecord({
  id: st.integer(),
  name: st.string()
})

sloppyUser({ id: 1, name: "Matt" })
// => { id: 1, name: "Matt" }

sloppyUser({ id: 1, name: "Matt", isAdmin: true })
// => { id: 1, name: "Matt" }

st.use(sloppyUser, { id: 1, name: "Matt", isAdmin: true })
// => { ok: true, result: { id: 1, name: "Matt" } }
```

### `nonStrict` modifier

A non-strict modifier allows strict `record` runtypes to be changed (modified) into non-strict versions, as opposed to having a separate non-strict runtype (see `sloppyRecord` above). Some of the reasons why this is desirable are outlined in #68. One of these reasons is that it allows for separation between the record's _definition_ and the way the record is _parsed_. The modifier approach is similar to the way the `pick`, `omit`, and `partial` runtypes work (they modify a record runtype in order to create a new runtype).

> **Note**: The "sloppy" terminology has negative connotations, and it looks untidy to have the word "sloppy" across a code base. Therefore, "sloppy" has been dropped in favour of "non-strict".

`record` runtypes continue to be strict by default, and the `nonStrict` modifier is used on an existing record runtype to create a new, non-strict record runtype. For example:

```ts
const nonStrictUser = st.nonStrict(
  st.record({
    id: st.integer(),
    name: st.string()
  })
)

nonStrictUser({ id: 1, name: "Matt" })
// => { id: 1, name: "Matt" }

nonStrictUser({ id: 1, name: "Matt", isAdmin: true })
// => { id: 1, name: "Matt" }

st.use(nonStrictUser, { id: 1, name: "Matt", isAdmin: true })
// => { ok: true, result: { id: 1, name: "Matt" } }
```

> **Note**: `nonStrict` does _not_ modify the given runtype in-place, but returns a new runtype based on the given runtype.

### Notes on capabilities and limitations

#### strict and `nonStrict` can be used in the same runtypes

```ts
const user = st.record({
  id: st.integer(),
  name: st.string(),
  company: st.nonStrict(
    st.record({
      id: st.integer(),
      name: st.string()
    })
  )
})

user({ id: 1, name: "Matt", company: { id: 1, name: "EasyJet" } })
// => { id: 1, name: "Matt", company: { id: 1, name: "EasyJet" } }

user({ id: 1, name: "Matt", company: { id: 1, name: "EasyJet", code: "EJ" } })
// => { id: 1, name: "Matt", company: { id: 1, name: "EasyJet" } }

user({ id: 1, name: "Matt", company: { id: 1, name: "EasyJet" }, isAdmin: true })
// => throws st.RuntypeError: invalid keys in record
```

#### `nonStrict` is not recursive

```ts
const nonStrictUser = st.nonStrict(
  st.record({
    id: st.integer(),
    name: st.string(),
    address: st.record({
      streetNumber: st.integer(),
      streetName: st.string()
    })
  })
)

nonStrictUser({ id: 1, name: "Matt", address: { streetNumber: 42, streetName: "Sesame St" } })
// => { id: 1, name: "Matt", address: { streetNumber: 42, streetName: "Sesame St" } }

nonStrictUser({ id: 1, name: "Matt", address: { streetNumber: 42, streetName: "Sesame St" } }, isAdmin: true)
// => { id: 1, name: "Matt", address: { streetNumber: 42, streetName: "Sesame St" } }

nonStrictUser({ id: 1, name: "Matt", address: { streetNumber: 42, streetName: "Sesame St", hasAlarm: true } })
// => throws st.RuntypeError: invalid keys in record
```

#### `nonStrict` can only be applied to records

Record runtypes include: `record`, `pick`, `omit`, `partial`, `intersection` (of two records).

```ts
// ✅
// returns non-strict record runtypes 
st.nonStrict(st.record({ id: st.integer(), name: st.string() }))
st.nonStrict(st.pick(st.record({ id: st.integer(), name: st.string() }), "id"))
st.nonStrict(st.omit(st.record({ id: st.integer(), name: st.string() }), "name"))
st.nonStrict(st.partial(st.record({ id: st.integer(), name: st.string() })))
st.nonStrict(st.intersection(st.record({ name: st.string() }), st.record({ age: st.number() })))

// ❌
// throws st.RuntypeUsageError expected a record runtype
st.nonStrict(st.string())
st.nonStrict(st.array(st.string()))
st.nonStrict(st.union(st.number(), st.string()))
// ...
```

### Compatibility

`sloppyRecord` can still be used. Under the hood, a `sloppyRecord` just uses the `nonStrict` functionality.